### PR TITLE
Added support for shim in resource group

### DIFF
--- a/.github/workflows/tflint.yaml
+++ b/.github/workflows/tflint.yaml
@@ -1,0 +1,40 @@
+name: Lint
+on:
+  pull_request:
+      branches:
+        - main
+
+jobs:
+  tflint:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+      name: Checkout source code
+
+    - uses: actions/cache@v3
+      name: Cache plugin dir
+      with:
+        path: ~/.tflint.d/plugins
+        key: ${{ matrix.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
+
+    - uses: terraform-linters/setup-tflint@v3
+      name: Setup TFLint
+      with:
+        tflint_version: v0.47.0
+
+    - name: Show version
+      run: tflint --version
+
+    - name: Init TFLint
+      run: tflint --init
+      env:
+        # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Run TFLint
+      run: tflint --minimum-failure-severity=error -f compact

--- a/README.md
+++ b/README.md
@@ -21,19 +21,22 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_location"></a> [location](#input\_location) | Location | `any` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | Resource Group Name | `any` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | Location | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Resource Group Name | `string` | n/a | yes |
+| <a name="input_shim"></a> [shim](#input\_shim) | If true will not create the resource group | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags common to all the resources created | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | n/a |
 | <a name="output_resource_group_location"></a> [resource\_group\_location](#output\_resource\_group\_location) | n/a |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | n/a |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ Truefoundry Azure Resource Group Module
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.69.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.69.0 |
 
 ## Modules
 
@@ -20,8 +23,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,12 @@
 resource "azurerm_resource_group" "this" {
+  count    = var.shim ? 0 : 1
   name     = var.name
   location = var.location
 
   tags = local.tags
+}
+
+data "azurerm_resource_group" "this" {
+  count = var.shim ? 1 : 0
+  name  = var.name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,11 @@
 output "resource_group_name" {
-  value = azurerm_resource_group.this.name
+  value = var.name
 }
 
 output "resource_group_location" {
-  value = azurerm_resource_group.this.location
+  value = var.shim ? data.azurerm_resource_group.this[0].location : azurerm_resource_group.this[0].location
+}
+
+output "resource_group_id" {
+  value = var.shim ? data.azurerm_resource_group.this[0].id : azurerm_resource_group.this[0].id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,23 @@
+##################################################################################
+## Variables
+##################################################################################
+
+### Shim
+variable "shim" {
+  description = "If true will not create the resource group"
+  type        = bool
+  default     = false
+}
+
+## Non Shim
 variable "name" {
   description = "Resource Group Name"
+  type        = string
 }
 
 variable "location" {
   description = "Location"
+  type        = string
 }
 
 variable "tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.69.0"
+    }
+  }
+}


### PR DESCRIPTION
SHIM support added for resource group

1. if `shim` is `true` skip resource group creation.
2. `shim` defaults to `false`
3. use `data` resource to fetch already existing resource group in case of `shim`
4. Added output of resource group id as `resource_group_id`